### PR TITLE
Fix for MySQL default timestamp fields.

### DIFF
--- a/lib/ShinyCMS/Schema/Result/Event.pm
+++ b/lib/ShinyCMS/Schema/Result/Event.pm
@@ -75,14 +75,14 @@ __PACKAGE__->table("event");
 
   data_type: 'timestamp'
   datetime_undef_if_invalid: 1
-  default_value: '1970-01-01 01:01:01'
+  default_value: current_timestamp
   is_nullable: 0
 
 =head2 end_date
 
   data_type: 'timestamp'
   datetime_undef_if_invalid: 1
-  default_value: '1970-01-01 01:01:01'
+  default_value: "1971-01-01 01:01:01",
   is_nullable: 0
 
 =head2 postcode
@@ -126,14 +126,14 @@ __PACKAGE__->add_columns(
   {
     data_type => "timestamp",
     datetime_undef_if_invalid => 1,
-    default_value => "1970-01-01 01:01:01",
+    default_value => \"current_timestamp",
     is_nullable => 0,
   },
   "end_date",
   {
     data_type => "timestamp",
     datetime_undef_if_invalid => 1,
-    default_value => "1970-01-01 01:01:01",
+    default_value => "1971-01-01 01:01:01",
     is_nullable => 0,
   },
   "postcode",

--- a/lib/ShinyCMS/Schema/Result/ForumPost.pm
+++ b/lib/ShinyCMS/Schema/Result/ForumPost.pm
@@ -93,7 +93,7 @@ __PACKAGE__->table("forum_post");
 
   data_type: 'timestamp'
   datetime_undef_if_invalid: 1
-  default_value: '1970-01-01 01:01:01'
+  default_value: '1971-01-01 01:01:01'
   is_nullable: 0
 
 =head2 discussion
@@ -130,7 +130,7 @@ __PACKAGE__->add_columns(
   {
     data_type => "timestamp",
     datetime_undef_if_invalid => 1,
-    default_value => "1970-01-01 01:01:01",
+    default_value => '1971-01-01 01:01:01',
     is_nullable => 0,
   },
   "discussion",


### PR DESCRIPTION
Default time stamp will not work on MySQL version earlier than 5.6.5.

A workaround could be to use DBIx::Class::TimeStamp and leave the DB fields null-able or without defaults.
