### PR TITLE
Add 'frozen' state to discussions

### DIFF
--- a/bin/database/data/insert-required-data
+++ b/bin/database/data/insert-required-data
@@ -36,6 +36,7 @@ $schema->resultset( 'Role' )->find_or_create({ role => 'Blog Author'            
 $schema->resultset( 'Role' )->find_or_create({ role => 'Blog Admin'                });
 $schema->resultset( 'Role' )->find_or_create({ role => 'Forums Admin'              });
 $schema->resultset( 'Role' )->find_or_create({ role => 'Comment Moderator'         });
+$schema->resultset( 'Role' )->find_or_create({ role => 'Discussion Admin'          });
 $schema->resultset( 'Role' )->find_or_create({ role => 'Poll Admin'                });
 $schema->resultset( 'Role' )->find_or_create({ role => 'Events Admin'              });
 $schema->resultset( 'Role' )->find_or_create({ role => 'Shop Admin'                });

--- a/docs/database/schema.sql
+++ b/docs/database/schema.sql
@@ -112,6 +112,7 @@ create table if not exists discussion (
 	id				int				not null auto_increment,
 	resource_id		int				not null,
 	resource_type	varchar(50)		not null,
+	frozen          tinyint(1)      not null default 0,
 
 	created			timestamp		not null default current_timestamp,
 

--- a/lib/ShinyCMS/Controller/Discussion.pm
+++ b/lib/ShinyCMS/Controller/Discussion.pm
@@ -134,18 +134,8 @@ Display the form to allow users to post a comment in reply to top-level content.
 sub add_comment : Chained( 'base' ) : PathPart( 'add-comment' ) : Args( 0 ) {
 	my ( $self, $c ) = @_;
 
-	my $level = $self->can_comment;
-
-	if ( $level eq 'User' and not $c->user_exists ) {
-		# check for logged-in user
-		$c->go( 'User', 'login' );
-	}
-
-	# Stash the item being replied to
-	my $type = $c->stash->{ discussion }->resource_type;
-	$c->stash->{ parent } = $c->model( 'DB::'.$type )->find({
-		id => $c->stash->{ discussion }->resource_id,
-	});
+	# Check whether only logged-in users can comment, and enforce it
+	$c->go( 'User', 'login' ) if $self->can_comment eq 'User' and not $c->user_exists;
 
 	# Find pseudonymous user details in cookie, if any, and stash them
 	my $cookie = $c->request->cookies->{ comment_author_info };
@@ -157,6 +147,12 @@ sub add_comment : Chained( 'base' ) : PathPart( 'add-comment' ) : Args( 0 ) {
 			comment_author_email => $val{ comment_author_email } || undef,
 		);
 	}
+
+	# Stash the item being replied to
+	my $type = $c->stash->{ discussion }->resource_type;
+	$c->stash->{ parent } = $c->model( 'DB::'.$type )->find({
+		id => $c->stash->{ discussion }->resource_id,
+	});
 }
 
 
@@ -171,10 +167,8 @@ Display the form to allow users to post a comment in reply to another comment.
 sub reply_to : Chained( 'base' ) : PathPart( 'reply-to' ) : Args( 1 ) {
 	my ( $self, $c, $parent_id ) = @_;
 
-	# Stash the comment being replied to
-	$c->stash->{ parent } = $c->stash->{ discussion }->comments->find({
-		id => $parent_id,
-	});
+	# Check whether only logged-in users can comment, and enforce it
+	$c->go( 'User', 'login' ) if $self->can_comment eq 'User' and not $c->user_exists;
 
 	# Find pseudonymous user details in cookie, if any, and stash them
 	my $cookie = $c->request->cookies->{ comment_author_info };
@@ -186,6 +180,11 @@ sub reply_to : Chained( 'base' ) : PathPart( 'reply-to' ) : Args( 1 ) {
 			comment_author_email => $val{ comment_author_email } || undef,
 		);
 	}
+
+	# Stash the comment being replied to
+	$c->stash->{ parent } = $c->stash->{ discussion }->comments->find({
+		id => $parent_id,
+	});
 
 	$c->stash->{ template } = 'discussion/add_comment.tt';
 }
@@ -202,19 +201,22 @@ Process the form when a user posts a comment.
 sub add_comment_do : Chained( 'base' ) : PathPart( 'add-comment-do' ) : Args( 0 ) {
 	my ( $self, $c ) = @_;
 
-	my $level = $self->can_comment;
-
-	if ( $level eq 'User' ) {
+	if ( $self->can_comment eq 'User' ) {
 		unless ( $c->user_exists ) {
 			$c->flash->{ error_msg } = 'You must be logged in to post a comment.';
-			$c->response->redirect( $c->request->referer );
+			$c->response->redirect( $c->uri_for( '/user/login' ) );
 			$c->detach;
 		}
 	}
-	elsif ( $level eq 'Pseudonym' ) {
+	elsif ( $self->can_comment eq 'Pseudonym' ) {
 		unless ( $c->request->param( 'author_name' ) or $c->user_exists ) {
 			$c->flash->{ error_msg } = 'You must supply a name to post a comment.';
-			$c->response->redirect( $c->request->referer );
+			if ( $c->request->referer ) {
+				$c->response->redirect( $c->request->referer );
+			}
+			else {
+				$c->response->redirect( $c->uri_for( '/' ) );
+			}
 			$c->detach;
 		}
 	}
@@ -233,14 +235,14 @@ sub add_comment_do : Chained( 'base' ) : PathPart( 'add-comment-do' ) : Args( 0 
 
 	if ( $c->user_exists or $result->{ is_valid } ) {
 		# Save pseudonymous user details in cookie, if any
-		my $author = {
-			comment_author_name  => $c->request->param( 'author_name'  ),
-		};
-		$author->{ comment_author_link } = $c->request->param( 'author_link'  )
-			if $c->request->param( 'author_link'  );
-		$author->{ comment_author_email } = $c->request->param( 'author_email' )
-			if $c->request->param( 'author_email' );
 		if ( $author_type eq 'Unverified' ) {
+			my $author = {
+				comment_author_name => $c->request->param( 'author_name' ),
+			};
+			$author->{ comment_author_link } = $c->request->param( 'author_link' )
+				if $c->request->param( 'author_link' );
+			$author->{ comment_author_email } = $c->request->param( 'author_email' )
+				if $c->request->param( 'author_email' );
 			$c->response->cookies->{ comment_author_info } = {
 				value => $author,
 			};
@@ -270,7 +272,7 @@ sub add_comment_do : Chained( 'base' ) : PathPart( 'add-comment-do' ) : Args( 0 
 				id           => $next_id,
 				parent       => $c->request->param( 'parent_id'    ) || undef,
 				author_type  => 'Unverified',
-				author_name  => $c->request->param( 'author_name'  ) || undef,
+				author_name  => $c->request->param( 'author_name'  ),
 				author_email => $c->request->param( 'author_email' ) || undef,
 				author_link  => $c->request->param( 'author_link'  ) || undef,
 				title        => $c->request->param( 'title'        ) || undef,
@@ -289,12 +291,10 @@ sub add_comment_do : Chained( 'base' ) : PathPart( 'add-comment-do' ) : Args( 0 
 
 		# Update commented_on timestamp for forum posts
 		if ( $c->stash->{ discussion}->resource_type eq 'ForumPost' ) {
-			my $now = DateTime->now;
-			my $post = $c->model( 'DB::ForumPost' )->find({
+			$c->model( 'DB::ForumPost' )->find({
 				id => $c->stash->{ discussion}->resource_id,
-			});
-			$post->update({
-				commented_on => $now,
+			})->update({
+				commented_on => \'current_timestamp',
 			});
 		}
 
@@ -320,9 +320,7 @@ Like (or unlike) a comment.
 sub like_comment : Chained( 'base' ) : PathPart( 'like' ) : Args( 1 ) {
 	my ( $self, $c, $comment_id ) = @_;
 
-	my $level = $self->can_like;
-
-	if ( $level eq 'User' ) {
+	if ( $self->can_like eq 'User' ) {
 		unless ( $c->user_exists ) {
 			$c->flash->{ error_msg } = 'You must be logged in to like a comment.';
 			$c->response->redirect( $c->request->referer );
@@ -482,32 +480,32 @@ Build URL for stashed content (and comment, if any)
 sub build_url : Private {
 	my ( $self, $c ) = @_;
 
-	my $discussion = $c->stash->{ discussion };
-	my $comment    = $c->stash->{ comment    };
-
-	my $resource = $c->model( 'DB::'.$discussion->resource_type )->find({
-		id => $discussion->resource_id,
+	# Check the primary parent resource (blog post/shop item/etc) still exists
+	my $resource_type = $c->stash->{ discussion }->resource_type;
+	my $resource = $c->model( 'DB::'.$resource_type )->find({
+		id => $c->stash->{ discussion }->resource_id,
 	});
 	return unless $resource;
 
+	my $comment = $c->stash->{ comment };
 	my $url;
-	if ( $discussion->resource_type eq 'BlogPost' ) {
+	if ( $resource_type eq 'BlogPost' ) {
 		$url  = $c->uri_for( '/blog', $resource->posted->year, $resource->posted->month, $resource->url_title );
 		$url .= '#comment-'. $comment->id if $comment;
 	}
-	elsif ( $discussion->resource_type eq 'ForumPost' ) {
+	elsif ( $resource_type eq 'ForumPost' ) {
 		$url  = $c->uri_for( '/forums', $resource->forum->section->url_name, $resource->forum->url_name, $resource->id, $resource->url_title );
 		$url .= '#comment-'. $comment->id if $comment;
 	}
-	elsif ( $discussion->resource_type eq 'NewsItem' ) {
+	elsif ( $resource_type eq 'NewsItem' ) {
 		$url  = $c->uri_for( '/news', $resource->posted->year, $resource->posted->month, $resource->url_title );
 		$url .= '#comment-'. $comment->id if $comment;
 	}
-	elsif ( $discussion->resource_type eq 'ShopItem' ) {
+	elsif ( $resource_type eq 'ShopItem' ) {
 		$url  = $c->uri_for( '/shop', 'item', $resource->code );
 		$url .= '#comment-'. $comment->id if $comment;
 	}
-	elsif ( $discussion->resource_type eq 'User' ) {
+	elsif ( $resource_type eq 'User' ) {
 		$url  = $c->uri_for( '/user', $resource->username );
 		$url .= '#comment-'. $comment->id if $comment;
 	}

--- a/lib/ShinyCMS/Controller/Discussion.pm
+++ b/lib/ShinyCMS/Controller/Discussion.pm
@@ -480,7 +480,7 @@ sub freeze_discussion : Chained( 'base' ) : PathPart( 'freeze' ) : Args( 0 ) {
 
 	# Check to make sure user has the required permissions
 	return 0 unless $self->user_exists_and_can($c, {
-		action   => 'freeze the discussion',
+		action   => 'freeze a discussion',
 		role     => 'Discussion Admin',
 		redirect => $url
 	});
@@ -506,7 +506,7 @@ sub unfreeze_discussion : Chained( 'base' ) : PathPart( 'unfreeze' ) : Args( 0 )
 
 	# Check to make sure user has the required permissions
 	return 0 unless $self->user_exists_and_can($c, {
-		action   => 'unfreeze the discussion',
+		action   => 'unfreeze a discussion',
 		role     => 'Discussion Admin',
 		redirect => $url
 	});

--- a/lib/ShinyCMS/Controller/Discussion.pm
+++ b/lib/ShinyCMS/Controller/Discussion.pm
@@ -134,6 +134,12 @@ Display the form to allow users to post a comment in reply to top-level content.
 sub add_comment : Chained( 'base' ) : PathPart( 'add-comment' ) : Args( 0 ) {
 	my ( $self, $c ) = @_;
 
+	# Check whether discussion is frozen
+	if ( $c->stash->{ discussion }->frozen ) {
+		$c->flash->{ error_msg } = 'Discussion is frozen; no new comments allowed.';
+		$self->build_url_and_redirect( $c );
+	}
+
 	# Check whether only logged-in users can comment, and enforce it
 	$c->go( 'User', 'login' ) if $self->can_comment eq 'User' and not $c->user_exists;
 
@@ -166,6 +172,12 @@ Display the form to allow users to post a comment in reply to another comment.
 
 sub reply_to : Chained( 'base' ) : PathPart( 'reply-to' ) : Args( 1 ) {
 	my ( $self, $c, $parent_id ) = @_;
+
+	# Check whether discussion is frozen
+	if ( $c->stash->{ discussion }->frozen ) {
+		$c->flash->{ error_msg } = 'Discussion is frozen; no new comments allowed.';
+		$self->build_url_and_redirect( $c );
+	}
 
 	# Check whether only logged-in users can comment, and enforce it
 	$c->go( 'User', 'login' ) if $self->can_comment eq 'User' and not $c->user_exists;
@@ -201,6 +213,13 @@ Process the form when a user posts a comment.
 sub add_comment_do : Chained( 'base' ) : PathPart( 'add-comment-do' ) : Args( 0 ) {
 	my ( $self, $c ) = @_;
 
+	# Check whether discussion is frozen
+	if ( $c->stash->{ discussion }->frozen ) {
+		$c->flash->{ error_msg } = 'Discussion is frozen; no new comments allowed.';
+		$self->build_url_and_redirect( $c );
+	}
+
+	# Check whether current user is allowed to post a comment, bounce if not
 	if ( $self->can_comment eq 'User' ) {
 		unless ( $c->user_exists ) {
 			$c->flash->{ error_msg } = 'You must be logged in to post a comment.';

--- a/lib/ShinyCMS/Controller/Discussion.pm
+++ b/lib/ShinyCMS/Controller/Discussion.pm
@@ -467,6 +467,58 @@ sub delete_comment : Chained( 'base' ) : PathPart( 'delete' ) : Args( 1 ) {
 }
 
 
+=head2 freeze_discussion
+
+Freeze the discussion (no new comments allowed)
+
+=cut
+
+sub freeze_discussion : Chained( 'base' ) : PathPart( 'freeze' ) : Args( 0 ) {
+	my ( $self, $c ) = @_;
+
+	my $url = $self->build_url( $c );
+
+	# Check to make sure user has the required permissions
+	return 0 unless $self->user_exists_and_can($c, {
+		action   => 'freeze the discussion',
+		role     => 'Discussion Admin',
+		redirect => $url
+	});
+
+	$c->stash->{ discussion }->update({ frozen => 1 });
+	$c->flash->{ status_msg } = 'Discussion frozen';
+
+	# Bounce back to the discussion location
+	$self->build_url_and_redirect( $c, $url );
+}
+
+
+=head2 unfreeze_discussion
+
+Unfreeze the discussion (new comments allowed)
+
+=cut
+
+sub unfreeze_discussion : Chained( 'base' ) : PathPart( 'unfreeze' ) : Args( 0 ) {
+	my ( $self, $c ) = @_;
+
+	my $url = $self->build_url( $c );
+
+	# Check to make sure user has the required permissions
+	return 0 unless $self->user_exists_and_can($c, {
+		action   => 'unfreeze the discussion',
+		role     => 'Discussion Admin',
+		redirect => $url
+	});
+
+	$c->stash->{ discussion }->update({ frozen => 0 });
+	$c->flash->{ status_msg } = 'Discussion unfrozen';
+
+	# Bounce back to the discussion location
+	$self->build_url_and_redirect( $c, $url );
+}
+
+
 # ========== ( utility methods ) ==========
 
 =head2 delete_comment_tree

--- a/lib/ShinyCMS/Schema/Result/Discussion.pm
+++ b/lib/ShinyCMS/Schema/Result/Discussion.pm
@@ -59,6 +59,12 @@ __PACKAGE__->table("discussion");
   is_nullable: 0
   size: 50
 
+=head2 frozen
+
+  data_type: 'tinyint'
+  default_value: 0
+  is_nullable: 0
+
 =head2 created
 
   data_type: 'timestamp'
@@ -75,6 +81,8 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 0 },
   "resource_type",
   { data_type => "varchar", is_nullable => 0, size => 50 },
+  "frozen",
+  { data_type => "tinyint", default_value => 0, is_nullable => 0 },
   "created",
   {
     data_type => "timestamp",
@@ -174,8 +182,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07033 @ 2013-03-08 18:42:22
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:RI8Obj+D/TgCvADEr8N3DQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-09-19 22:19:06
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:IvIEMWG2z+XUNbPblEfGwQ
 
 
 __PACKAGE__->has_many(

--- a/root/admin/site-toolbar.tt
+++ b/root/admin/site-toolbar.tt
@@ -2,6 +2,7 @@
 	OR c.user.has_role( 'Blog Author'      )
 	OR c.user.has_role( 'CMS Page Admin'   )
 	OR c.user.has_role( 'CMS Page Editor'  )
+	OR c.user.has_role( 'Discussion Admin' )
 	OR c.user.has_role( 'Events Admin'     )
 	OR c.user.has_role( 'Forums Admin'     )
 	OR c.user.has_role( 'News Admin'       )
@@ -19,6 +20,15 @@
 		[%- IF preview == 'preview' %]
 		<a href="javascript:window.close()">Close Preview</a>
 		[%- ELSE %]
+
+		[%- IF discussion AND c.user.has_role( 'Discussion Admin' ) %]
+		[%- IF discussion.frozen %]
+		<a href="[% c.uri_for( '/discussion', discussion.id, 'unfreeze' ) %]">Unfreeze discussion</a>
+		[%- ELSE %]
+		<a href="[% c.uri_for( '/discussion', discussion.id, 'freeze' ) %]">Freeze discussion</a>
+		[%- END %]
+		|
+		[%- END %]
 
 		[%- IF controller == 'Blog' AND
 			( c.user.has_role( 'Blog Author' ) OR c.user.has_role( 'Blog Admin' ) ) %]

--- a/t/controllers/controller_Discussion.t
+++ b/t/controllers/controller_Discussion.t
@@ -317,6 +317,64 @@ $t->text_contains(
 	'Verified that comment was deleted'
 );
 
+# Try to freeze/unfreeze discussion when not logged in as Discussion Admin
+$t->get( "/discussion/$blog_discussion_id/freeze" );
+$t->text_contains(
+	'You do not have the ability to freeze a discussion.',
+	'Attempting to freeze discussion when not logged in as admin gets error'
+);
+$t->get( "/discussion/$blog_discussion_id/unfreeze" );
+$t->text_contains(
+	'You do not have the ability to unfreeze a discussion.',
+	'Attempting to unfreeze discussion when not logged in as admin gets error'
+);
+
+# Login as Discussion Admin and freeze/unfreeze discussion
+my $admin = create_test_admin( 'test_discussion_admin', 'Discussion Admin' );
+$t = login_test_user( $admin->username, $admin->username )
+	or die 'Failed to log in as Discussion Admin';
+# Check login was successful
+$c = $t->ctx;
+ok(
+	$c->user->has_role( 'Discussion Admin' ),
+	'Logged in as Discussion Admin'
+);
+$t->get( $path );
+$t->follow_link_ok(
+	{ text => 'Freeze discussion' },
+	"Click 'Freeze discussion' link"
+);
+$t->text_contains(
+	'Discussion frozen',
+	'Got confirmation message that discussion has been frozen'
+);
+$t->follow_link_ok(
+	{ text => 'Add a new comment' },
+	"Click 'Add a new comment' link"
+);
+$t->text_contains(
+	'Discussion is frozen; no new comments allowed.',
+	'Got error message warning user that discussion has been frozen'
+);
+$t->get( $path );
+$t->follow_link_ok(
+	{ text => 'Unfreeze discussion' },
+	"Click 'Unfreeze discussion' link"
+);
+$t->text_contains(
+	'Discussion unfrozen',
+	'Got confirmation message that discussion has been frozen'
+);
+$t->follow_link_ok(
+	{ text => 'Add a new comment' },
+	"Click 'Add a new comment' link again"
+);
+$t->text_contains(
+	'Add your comment:',
+	'Got form for adding a new comment'
+);
+
+
 # Call search method without setting search param
 $c = $t->ctx;
 my $results = $c->controller( 'Discussion' )->search( $c );


### PR DESCRIPTION
Toggling freeze/unfreeze on a discussion prevents/allows new comments. A new role (Discussion Admin) has the ability to use this feature.