### PR TITLE
Enable dist building

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,82 @@
+#!start included .../ExtUtils/MANIFEST.SKIP
+# Avoid version control files.
+\bRCS\b
+\bCVS\b
+\bSCCS\b
+,v$
+\B\.svn\b
+\B\.git\b
+\B\.gitignore\b
+\b_darcs\b
+\B\.cvsignore$
+
+# Avoid VMS specific MakeMaker generated files
+\bDescrip.MMS$
+\bDESCRIP.MMS$
+\bdescrip.mms$
+
+# Avoid Makemaker generated and utility files.
+\bMANIFEST\.bak
+\bMakefile$
+\bblib/
+\bMakeMaker-\d
+\bpm_to_blib\.ts$
+\bpm_to_blib$
+\bblibdirs\.ts$         # 6.18 through 6.25 generated this
+\b_eumm/                # 7.05_05 and above
+
+# Avoid Module::Build generated and utility files.
+\bBuild$
+\b_build/
+\bBuild.bat$
+\bBuild.COM$
+\bBUILD.COM$
+\bbuild.com$
+
+# and Module::Build::Tiny generated files
+\b_build_params$
+
+# Avoid temp and backup files.
+~$
+\.old$
+\#$
+\b\.#
+\.bak$
+\.tmp$
+\.#
+\.rej$
+\..*\.sw.?$
+
+# Avoid OS-specific files/dirs
+# Mac OSX metadata
+\B\.DS_Store
+# Mac OSX SMB mount metadata files
+\B\._
+
+# Avoid Devel::Cover and Devel::CoverX::Covered files.
+\bcover_db\b
+\bcovered\b
+
+# Avoid prove files
+\B\.prove$
+
+# Avoid MYMETA files
+^MYMETA\.
+
+# Temp files for new META
+^META_new\.(?:json|yml)
+
+# Avoid travis-ci.org file
+^\.travis\.yml
+
+# Avoid AppVeyor file
+^\.?appveyor.yml
+#!end included .../ExtUtils/MANIFEST.SKIP
+
+# Avoid plenv and carton files
+^.perl-version
+^cpanfile
+^local/
+
+# Avoid dist dir and distfiles
+^Shiny-*

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -68,5 +68,6 @@ recommends (
 catalyst;
 
 install_script glob( 'script/*.pl' );
+tests 't/*/*.t';
 auto_install;
 WriteAll;


### PR DESCRIPTION
With the dependencies installed, this lets me:

```
perl Makefile.pl
make manifest
make disttest
make dist
```

This gives me a ShinyCMS-19.9.tar.gz that I expect could be uploaded to the CPAN and would address issue #70. 

However, I don't think the install would be useful as cpan clients won't know what to do do with the `root/` directory and although it will install the files in the `script/` directory and the `bin/` dir is included in the dist, the files there won't get installed (which I think is correct).

In any case, I ended up here from the pullrequest.club and so I don't know a whole lot about ShinyCMS and I'm sure the README will need some updates explaining how to install from the CPAN.  I'm happy to help figure out some of these challenges as well.